### PR TITLE
Improve output for alerts

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -15,7 +15,7 @@ type AlertOverview struct {
 	Output []string
 }
 
-func CheckAlerts(client *api.Client) (o *AlertOverview, err error) {
+func CheckAlerts(client *api.Client, names EndpointNames) (o *AlertOverview, err error) {
 	o = &AlertOverview{}
 
 	alerts, err := client.GetAlerts()
@@ -35,8 +35,14 @@ func CheckAlerts(client *api.Client) (o *AlertOverview, err error) {
 			o.Low++
 		}
 
-		output := fmt.Sprintf("[%s] %s: %s group=%s",
-			alert.RaisedAt, alert.Type, alert.Description, alert.GroupKey)
+		agentName := alert.ManagedAgent.ID
+		if val, ok := names[agentName]; ok {
+			agentName = val
+		}
+
+		output := fmt.Sprintf("%s [%s] %s (%s) %s",
+			alert.RaisedAt.Format("2006-01-02 15:04"),
+			alert.Severity, agentName, alert.Product, alert.Description)
 		o.Output = append(o.Output, output)
 	}
 
@@ -79,7 +85,7 @@ func (o *AlertOverview) GetOutput() (s string) {
 		return
 	}
 
-	s = "\n## Alerts"
+	s = "\n## Alerts\n"
 	s += strings.Join(o.Output, "\n")
 	s += "\n"
 

--- a/alerts.go
+++ b/alerts.go
@@ -41,7 +41,7 @@ func CheckAlerts(client *api.Client, names EndpointNames) (o *AlertOverview, err
 		}
 
 		output := fmt.Sprintf("%s [%s] %s (%s) %s",
-			alert.RaisedAt.Format("2006-01-02 15:04"),
+			alert.RaisedAt.Local().Format("2006-01-02 15:04 MST"),
 			alert.Severity, agentName, alert.Product, alert.Description)
 		o.Output = append(o.Output, output)
 	}

--- a/api/alerts.go
+++ b/api/alerts.go
@@ -14,10 +14,10 @@ type Alert struct {
 	// endpointFirewall, fenc, forensicSnapshot, general, iaas, iaasAzure, isolation, malware, mtr, mobiles, policy,
 	// protection, pua, runtimeDetections, security, smc, systemHealth, uav, uncategorized, updating, utm, virt,
 	// wireless, xgEmail
-	Category     string          `json:"category"`
-	Description  string          `json:"description"`
-	GroupKey     string          `json:"groupKey"`
-	ManagedAgent json.RawMessage `json:"managedAgent"`
+	Category     string            `json:"category"`
+	Description  string            `json:"description"`
+	GroupKey     string            `json:"groupKey"`
+	ManagedAgent AlertManagedAgent `json:"managedAgent"`
 	// Product types.
 	//
 	// The following values are allowed:
@@ -31,6 +31,11 @@ type Alert struct {
 	// high, medium, low
 	Severity string `json:"severity"`
 	// Alert type.
+	Type string `json:"type"`
+}
+
+type AlertManagedAgent struct {
+	ID   string `json:"id"`
 	Type string `json:"type"`
 }
 

--- a/check.go
+++ b/check.go
@@ -61,14 +61,14 @@ func (c *Config) Run() (rc int, output string, err error) {
 
 	log.WithField("context-id", client.UserInfo.ID).Debug("successfully authenticated with the API")
 
-	// Retrieve and check alerts
-	alerts, err := CheckAlerts(client)
+	// Retrieve and check endpoints
+	endpoints, names, err := CheckEndpoints(client)
 	if err != nil {
 		return
 	}
 
-	// Retrieve and check endpoints
-	endpoints, err := CheckEndpoints(client)
+	// Retrieve and check alerts
+	alerts, err := CheckAlerts(client, names)
 	if err != nil {
 		return
 	}

--- a/endpoints.go
+++ b/endpoints.go
@@ -14,8 +14,11 @@ type EndpointOverview struct {
 	Unknown    []string
 }
 
-func CheckEndpoints(client *api.Client) (o *EndpointOverview, err error) {
+type EndpointNames map[string]string
+
+func CheckEndpoints(client *api.Client) (o *EndpointOverview, names EndpointNames, err error) {
 	o = &EndpointOverview{}
+	names = EndpointNames{}
 
 	endpoints, err := client.GetEndpoints()
 	if err != nil {
@@ -23,6 +26,8 @@ func CheckEndpoints(client *api.Client) (o *EndpointOverview, err error) {
 	}
 
 	for _, endpoint := range endpoints {
+		names[endpoint.ID] = endpoint.Hostname
+
 		o.Total++
 
 		switch endpoint.Health.Overall {


### PR DESCRIPTION
Since I now have some test alerts, I could improve the output.

```
CRITICAL - alerts: 2 medium - endpoints: 2 good, 3 bad, 6 suspicious

## Alerts
2020-09-04 07:31 CEST [medium] TEST (server) PUA detected: 'PsExec' at 'E:\UserShares$\Max Mustermann\Desktop\PSTools.zip\PsExec.exe\FILE:0000'
2020-09-04 07:31 CEST [medium] TEST (server) PUA detected: 'PsKill' at 'E:\UserShares$\Max Mustermann\Desktop\PSTools.zip\pskill.exe'

## Endpoints
bad: HOST1
suspicious: HOST2, HOST3
| 'alerts'=2 'alerts_high'=0 'alerts_medium'=2 'alerts_low'=0 'endpoints_total'=11 'endpoints_good'=2 'endpoints_bad'=3 'endpoints_suspicious'=6 'endpoints_unknown'=0
```