### PR TITLE
Add parameter to exclude Alerts and Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@ The plugin currently checks the state of all alerts and endpoints within a tenan
 
 ```
 Arguments:
-      --client-id string       API Client ID (env:SOPHOS_CLIENT_ID)
-      --client-secret string   API Client Secret (env:SOPHOS_CLIENT_SECRET)
-      --show-all               List all non-ok endpoints
-      --api string             API Base URL (default "https://api.central.sophos.com")
-  -t, --timeout int            Abort the check after n seconds (default 30)
-  -d, --debug                  Enable debug mode
-  -v, --verbose                Enable verbose mode
-  -V, --version                Print version and exit
+      --client-id string               API Client ID (env:SOPHOS_CLIENT_ID)
+      --client-secret string           API Client Secret (env:SOPHOS_CLIENT_SECRET)
+      --show-all                       List all non-ok endpoints
+      --page-size uint32               Amount of objects to fetch during each API call (default 100)
+      --exclude-alert stringArray      Alerts to ignore. Can be used multiple times and supports regex.
+      --exclude-endpoint stringArray   Endpoints to ignore. Can be used multiple times and supports regex.
+      --api string                     API Base URL (default "https://api.central.sophos.com")
+  -t, --timeout int                    Abort the check after n seconds (default 30)
+  -d, --debug                          Enable debug mode
+  -v, --verbose                        Enable verbose mode
+  -V, --version                        Print version and exit
 ```
 
 ## Example

--- a/alerts.go
+++ b/alerts.go
@@ -15,7 +15,9 @@ type AlertOverview struct {
 	Output []string
 }
 
-func CheckAlerts(client *api.Client, names EndpointNames) (o *AlertOverview, err error) {
+// Retrieve and process Alerts
+// alertsToExclude is a list of strings that can the used to exclude alerts
+func CheckAlerts(client *api.Client, names EndpointNames, alertsToExclude []string) (o *AlertOverview, err error) {
 	o = &AlertOverview{}
 
 	alerts, err := client.GetAlerts()
@@ -24,6 +26,12 @@ func CheckAlerts(client *api.Client, names EndpointNames) (o *AlertOverview, err
 	}
 
 	for _, alert := range alerts {
+		if matches(alert.String(), alertsToExclude) {
+			// If the alert matches a regex from the list
+			// we can skip it
+			continue
+		}
+
 		o.Total++
 
 		switch strings.ToLower(alert.Severity) {

--- a/api/alerts.go
+++ b/api/alerts.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -32,6 +33,20 @@ type Alert struct {
 	Severity string `json:"severity"`
 	// Alert type.
 	Type string `json:"type"`
+}
+
+func (a *Alert) String() string {
+	return fmt.Sprintf(
+		"%v [%v] %v %v %v %v %v %v",
+		a.RaisedAt.Format("2006-01-02 15:04"),
+		a.Severity,
+		a.ID,
+		a.Product,
+		a.Description,
+		a.Type,
+		a.Category,
+		a.GroupKey,
+	)
 }
 
 type AlertManagedAgent struct {

--- a/api/alerts_test.go
+++ b/api/alerts_test.go
@@ -1,10 +1,12 @@
 package api_test
 
 import (
+	"github.com/NETWAYS/check_sophos_central/api"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+	"time"
 )
 
 const alertsResponse = `{
@@ -37,6 +39,39 @@ const alertsResponse = `{
 		}
 	]
 }`
+
+func TestAlert_String(t *testing.T) {
+	testcases := map[string]struct {
+		alert    api.Alert
+		expected string
+	}{
+		"default": {
+			alert: api.Alert{
+				RaisedAt: time.Date(2009, time.November, 11, 23, 0, 0, 0, time.UTC),
+			},
+			expected: "2009-11-11 23:00 []      ",
+		},
+		"custom-alert": {
+			alert: api.Alert{
+				ID:          "ID1",
+				RaisedAt:    time.Date(2009, time.November, 11, 23, 0, 0, 0, time.UTC),
+				Category:    "Cat",
+				Description: "Desc",
+				GroupKey:    "GK",
+				Product:     "Product",
+				Severity:    "critical",
+				Type:        "type",
+			},
+			expected: "2009-11-11 23:00 [critical] ID1 Product Desc type Cat GK",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.alert.String())
+		})
+	}
+}
 
 func TestClient_GetAlerts(t *testing.T) {
 	c := envClient(t)

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 type Endpoint struct {
@@ -30,6 +31,16 @@ type EndpointHealth struct {
 	Services json.RawMessage `json:"services"`
 	// Threats on the endpoint.
 	Threats json.RawMessage `json:"threats"`
+}
+
+func (e *Endpoint) String() string {
+	return fmt.Sprintf(
+		"%v [%v] %v %v",
+		e.Hostname,
+		e.Health.Overall,
+		e.ID,
+		e.Type,
+	)
 }
 
 func (c *Client) GetEndpoints() (endpoints []*Endpoint, err error) {

--- a/api/endpoints_test.go
+++ b/api/endpoints_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"github.com/NETWAYS/check_sophos_central/api"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"net/http"
@@ -87,6 +88,35 @@ const endpointsResponse = `{
         }
     ]
 }`
+
+func TestEndpoint_String(t *testing.T) {
+	testcases := map[string]struct {
+		endpoint api.Endpoint
+		expected string
+	}{
+		"default": {
+			endpoint: api.Endpoint{},
+			expected: " []  ",
+		},
+		"custom-endpoint": {
+			endpoint: api.Endpoint{
+				Hostname: "hostname",
+				ID:       "ID",
+				Health: api.EndpointHealth{
+					Overall: "cataclysmic",
+				},
+				Type: "Typ",
+			},
+			expected: "hostname [cataclysmic] ID Typ",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.endpoint.String())
+		})
+	}
+}
 
 func TestClient_GetEndpoints(t *testing.T) {
 	c := envClient(t)

--- a/endpoints.go
+++ b/endpoints.go
@@ -16,7 +16,7 @@ type EndpointOverview struct {
 
 type EndpointNames map[string]string
 
-func CheckEndpoints(client *api.Client) (o *EndpointOverview, names EndpointNames, err error) {
+func CheckEndpoints(client *api.Client, endpointsToExclude []string) (o *EndpointOverview, names EndpointNames, err error) { //nolint:lll
 	o = &EndpointOverview{}
 	names = EndpointNames{}
 
@@ -26,6 +26,12 @@ func CheckEndpoints(client *api.Client) (o *EndpointOverview, names EndpointName
 	}
 
 	for _, endpoint := range endpoints {
+		if matches(endpoint.String(), endpointsToExclude) {
+			// If the endpoint matches a regex from the list
+			// we can skip it
+			continue
+		}
+
 		names[endpoint.ID] = endpoint.Hostname
 
 		o.Total++

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMainAlerts_matches(t *testing.T) {
+	testcases := map[string]struct {
+		input    string
+		regex    []string
+		expected bool
+	}{
+		"simple-t": {
+			input:    "unittest",
+			regex:    []string{"unit", "foobar"},
+			expected: true,
+		},
+		"simple-f": {
+			input:    "unittest",
+			regex:    []string{"barfoo", "foobar"},
+			expected: false,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := matches(tc.input, tc.regex)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestMainAlerts_matches(t *testing.T) {
+func TestMainCheck_matches(t *testing.T) {
 	testcases := map[string]struct {
 		input    string
 		regex    []string
@@ -26,6 +26,78 @@ func TestMainAlerts_matches(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			actual := matches(tc.input, tc.regex)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestMainAlerts_GetPerfdata(t *testing.T) {
+	testcases := map[string]struct {
+		ao       AlertOverview
+		expected string
+	}{
+		"simple-overview": {
+			ao:       AlertOverview{},
+			expected: "'alerts'=0 'alerts_high'=0 'alerts_medium'=0 'alerts_low'=0",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := tc.ao.GetPerfdata()
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestMainAlerts_GetOutput(t *testing.T) {
+	testcases := map[string]struct {
+		ao       AlertOverview
+		expected string
+	}{
+		"simple-overview": {
+			ao: AlertOverview{
+				Total:  1,
+				Output: []string{"test"},
+			},
+			expected: "\n## Alerts\ntest\n",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := tc.ao.GetOutput()
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestMainAlerts_GetStatus(t *testing.T) {
+	testcases := map[string]struct {
+		ao       AlertOverview
+		expected int
+	}{
+		"simple-overview": {
+			ao:       AlertOverview{},
+			expected: 0,
+		},
+		"simple-warning": {
+			ao: AlertOverview{
+				Medium: 1,
+			},
+			expected: 1,
+		},
+		"simple-critical": {
+			ao: AlertOverview{
+				High: 1,
+			},
+			expected: 2,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := tc.ao.GetStatus()
 			assert.Equal(t, tc.expected, actual)
 		})
 	}


### PR DESCRIPTION
The idea is to have an `--exclude` parameter that can be used multiple times. This input will be a regular expression to be matched against the alert (transformed into a string).

I think this gives us maximum flexibility, since people might want to exclude alerts based on various content.

Fixes #6 